### PR TITLE
Update PyProject Toml - License

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "comfyui-centernode"
 description = "This extension contains a custom node for ComfyUI. The node, called 'Bounding Box Crop', is designed to compute the top-left coordinates of a cropped bounding box based on input coordinates and dimensions of the final cropped image. It does so computing the center of the cropping area and then computing where the top-left coordinates would be."
 version = "1.0.0"
-license = "LICENSE"
+license = { file = "LICENSE" }
 
 [project.urls]
 Repository = "https://github.com/alessandrozonta/ComfyUI-CenterNode"


### PR DESCRIPTION
Hey! Robin from [comfy.org](https://comfy.org/) again 😊.

As a heads up, the `license` field is **optional** but in the case that it is filled out, the license file should be referenced either by the file path or by the name of the license.
- `license = { file = "LICENSE" }` ✅
- `license = {text = "MIT License"}` ✅
- `license = "LICENSE"` ❌
- `license = "MIT LICENSE"` ❌

This was brought up in our discord and so we're creating a small PR to update that optional field. For more info check out toml file [standards](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license) or our [docs](https://docs.comfy.org/registry/specifications#license) page!